### PR TITLE
fix: remove explicit root User from agent container config

### DIFF
--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -562,7 +562,7 @@ func (d *DockerRuntime) DeployAgent(ctx context.Context, config AgentConfig) (*A
 	resp, err := d.client.ContainerCreate(ctx,
 		&container.Config{
 			Image: img,
-			User:  "0:0", // Start as root so entrypoint.sh can fix workspace permissions and drop privileges via gosu.
+	
 			Env:   env,
 			Labels: map[string]string{
 				LabelTeam:  config.TeamName,


### PR DESCRIPTION
AgentCrew was launching agent containers with User: '0:0' (root). Claude Code 2.1.92+ blocks --dangerously-skip-permissions when running as root, causing agents to exit silently with code 0 and no output.

The entrypoint.sh already handles user switching via gosu by detecting the workspace owner uid. Removing the explicit User field lets the entrypoint manage privileges correctly, making Claude Code 2.1.92+ work without downgrading or workarounds.

Fixes: silent exit 0 with no stdout when using Claude Code 2.1.92+